### PR TITLE
Update CEF version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CONFIGURATION_TYPES Release Debug)
 
 project(gst-cef)
 
-set(CEF_VERSION "3.3538.1849.g458cc98")
+set(CEF_VERSION "76.1.9+g2cf916e+chromium-76.0.3809.87")
 
 # Determine the platform.
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")

--- a/cmake/DownloadCEF.cmake
+++ b/cmake/DownloadCEF.cmake
@@ -31,6 +31,7 @@ function(DownloadCEF platform version download_dir)
 
       # Download the binary distribution and verify the hash.
       # message(STATUS "Downloading ${CEF_DOWNLOAD_PATH}...")
+      STRING(REPLACE "+" "%2B" CEF_DOWNLOAD_URL ${CEF_DOWNLOAD_URL})
       file(
         DOWNLOAD "${CEF_DOWNLOAD_URL}" "${CEF_DOWNLOAD_PATH}"
       #   EXPECTED_HASH SHA1=${CEF_SHA1}

--- a/src/browser_manager.cpp
+++ b/src/browser_manager.cpp
@@ -92,7 +92,7 @@ void Browser::CreateCefWindow(CefRefPtr<CefWindowManager> client) {
   CefBrowserSettings browser_settings;
   browser_settings.windowless_frame_rate = 30;
 
-  CefRefPtr<CefBrowser> browser = CefBrowserHost::CreateBrowserSync(window_info, client, client->GetUrl(), browser_settings, NULL);
+  CefRefPtr<CefBrowser> browser = CefBrowserHost::CreateBrowserSync(window_info, client, client->GetUrl(), browser_settings, NULL, NULL);
   browser->GetHost()->WasResized();
 }
 

--- a/src/cef_window_manager.cpp
+++ b/src/cef_window_manager.cpp
@@ -37,11 +37,11 @@ gst_cef_(gst_cef) {
 
 CefWindowManager::~CefWindowManager() {}
 
-bool CefWindowManager::GetViewRect(CefRefPtr<CefBrowser> browser, CefRect &rect)
+void CefWindowManager::GetViewRect(CefRefPtr<CefBrowser> browser, CefRect &rect)
 {
   //GST_LOG("GetViewRect: %uX%u", width_, height_);
   rect.Set(0, 0, width_, height_);
-  return true;
+  return;
 }
 
 void CefWindowManager::OnPaint(CefRefPtr<CefBrowser> browser, PaintElementType paintType, const RectList &rects,

--- a/src/cef_window_manager.h
+++ b/src/cef_window_manager.h
@@ -50,7 +50,7 @@ public:
                          CefRefPtr<CefFrame> frame,
                          int httpStatusCode) OVERRIDE;
 
-  bool GetViewRect(CefRefPtr<CefBrowser> browser, CefRect &rect);
+  void GetViewRect(CefRefPtr<CefBrowser> browser, CefRect &rect);
   void OnPaint(CefRefPtr<CefBrowser> browser, PaintElementType paintType,
                const RectList &rects, const void *buffer, int width, int height) OVERRIDE;
 

--- a/src/file_scheme_handler.cpp
+++ b/src/file_scheme_handler.cpp
@@ -15,7 +15,7 @@
 
 void RegisterFileSchemeHandlerFactory(CefRawPtr<CefSchemeRegistrar> registrar)
 {
-  registrar->AddCustomScheme(kFileSchemeProtocol, true, false, false, true, true, false);
+  registrar->AddCustomScheme(kFileSchemeProtocol, CEF_SCHEME_OPTION_STANDARD | CEF_SCHEME_OPTION_SECURE | CEF_SCHEME_OPTION_CORS_ENABLED);
 }
 
 FileSchemeHandler::FileSchemeHandler(CefString local_filepath)

--- a/src/subprocess.cpp
+++ b/src/subprocess.cpp
@@ -37,7 +37,7 @@ void BrowserApp::OnBeforeCommandLineProcessing(
 void BrowserApp::OnRegisterCustomSchemes(
     CefRawPtr<CefSchemeRegistrar> registrar)
 {
-  registrar->AddCustomScheme(kFileSchemeProtocol, true, false, false, true, true, false);
+  registrar->AddCustomScheme(kFileSchemeProtocol, CEF_SCHEME_OPTION_STANDARD | CEF_SCHEME_OPTION_SECURE | CEF_SCHEME_OPTION_CORS_ENABLED);
 }
 
 #ifdef _WIN32


### PR DESCRIPTION
I updated your solution to the latest CEF version (it is almost one-year-old). Solved build issues.
But after update I run command:
```
gst-cef/build$ GST_PLUGIN_PATH=$PWD/Release:$GST_PLUGIN_PATH Release/gst-launch-1.0 -v gstcef url="https://google.com" width=1280 height=720 ! queue ! videoconvert ! autovideosink
```
and it fails:
```
Setting pipeline to PAUSED ...
Pipeline is live and does not need PREROLL ...
Setting pipeline to PLAYING ...
New clock: GstSystemClock
/GstPipeline:pipeline0/GstCef:cef0.GstPad:src: caps = "video/x-raw\,\ format\=\(string\)BGRA\,\ framerate\=\(fraction\)0/1\,\ pixel-aspect-ratio\=\(fraction\)1/1\,\ width\=\(int\)1280\,\ height\=\(int\)720"
/GstPipeline:pipeline0/GstQueue:queue0.GstPad:sink: caps = "video/x-raw\,\ format\=\(string\)BGRA\,\ framerate\=\(fraction\)0/1\,\ pixel-aspect-ratio\=\(fraction\)1/1\,\ width\=\(int\)1280\,\ height\=\(int\)720"
/GstPipeline:pipeline0/GstQueue:queue0.GstPad:sink: caps = "video/x-raw\,\ format\=\(string\)BGRA\,\ framerate\=\(fraction\)0/1\,\ pixel-aspect-ratio\=\(fraction\)1/1\,\ width\=\(int\)1280\,\ height\=\(int\)720"
/GstPipeline:pipeline0/GstAutoVideoSink:autovideosink0/GstXImageSink:autovideosink0-actual-sink-ximage.GstPad:sink: caps = "video/x-raw\,\ framerate\=\(fraction\)0/1\,\ pixel-aspect-ratio\=\(fraction\)1/1\,\ width\=\(int\)1280\,\ height\=\(int\)720\,\ format\=\(string\)BGRx"
/GstPipeline:pipeline0/GstAutoVideoSink:autovideosink0.GstGhostPad:sink: caps = "video/x-raw\,\ framerate\=\(fraction\)0/1\,\ pixel-aspect-ratio\=\(fraction\)1/1\,\ width\=\(int\)1280\,\ height\=\(int\)720\,\ format\=\(string\)BGRx"
/GstPipeline:pipeline0/GstVideoConvert:videoconvert0.GstPad:sink: caps = "video/x-raw\,\ format\=\(string\)BGRA\,\ framerate\=\(fraction\)0/1\,\ pixel-aspect-ratio\=\(fraction\)1/1\,\ width\=\(int\)1280\,\ height\=\(int\)720"
Trace/breakpoint trap (core dumped)```